### PR TITLE
Use mktemp -d instead of relying on having /tmp in a usable state.

### DIFF
--- a/rocm-timeline-generator.sh
+++ b/rocm-timeline-generator.sh
@@ -34,7 +34,7 @@ tf_tl_prefix=`get_arg $3 "_none"`
 start_time=`get_arg $4 -1`
 end_time=`get_arg $5 -1`
 
-tmp=/tmp
+tmp=`mktemp -d`
 awk_fn=fn-rocm-timeline-generator.awk
 
 echo "log file ${log_file}"


### PR DESCRIPTION
rocm-timeline-generator.sh creates some temporary files in /tmp.  If these files already exist and are owned by another user, then the script fails.  To avoid this issue, we can create a safe temporary directory with mktemp -d.