### PR TITLE
Gendir

### DIFF
--- a/rocm-timeline-generator.sh
+++ b/rocm-timeline-generator.sh
@@ -35,7 +35,8 @@ start_time=`get_arg $4 -1`
 end_time=`get_arg $5 -1`
 
 tmp=/tmp
-awk_fn=fn-rocm-timeline-generator.awk
+scriptdir=$(dirname -- "$(realpath -- "$0")")
+awk_fn=${scriptdir}/fn-rocm-timeline-generator.awk
 
 echo "log file ${log_file}"
 


### PR DESCRIPTION
When called from a different directory, rocm-timeline-generator.sh looks for fn-rocm-timeline-generator.awk in the PWD.  This patch ensures that he .sh file looks for the .awk file which is from the same directory.