### PR TITLE
Empy tf

### DIFF
--- a/rocm-timeline-generator.sh
+++ b/rocm-timeline-generator.sh
@@ -130,6 +130,10 @@ if [[ "$count_timeline" -ge "1" ]]; then
       head -`echo "$lines - 3" | bc`;
     echo ",";
   done > ${timeline["tf"]}
+else
+  # the count_timeline is 0
+  echo "Count timeline is 0; creating trivial ${timeline["tf"]}"
+  touch ${timeline["tf"]}
 fi
 
 # compute a difference between the machine time and GPU time


### PR DESCRIPTION
When count_timeline is zero, timeline_tf.json is not created, and an error message is raised when rocm-timeline-generator.sh tries to access it with cat.  This patch creates an empty timeline_tf.json file to deal with this case.